### PR TITLE
Release BetterClaw plugin v3.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@ node_modules/
 dist/
 *.js
 !vitest.config.*
-docs/*
+docs/plans/
+docs/specs/
+docs/diagrams/*
+!docs/diagrams/
+!docs/diagrams/*.d2
 !docs/logging-schema.md
 .DS_Store
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ openclaw betterclaw setup   # configures gateway commands/tools and prompts for 
 openclaw gateway restart    # apply config changes when setup reports changes
 ```
 
+Installing from a source checkout requires a build first, because OpenClaw loads
+installed plugins from compiled JavaScript. Install the packed artifact instead
+of the checkout directory so OpenClaw scans the same file set that would ship to
+npm:
+
+```bash
+git clone https://github.com/BetterClaw-app/betterclaw.git
+cd betterclaw
+npm install
+npm run build
+TARBALL=$(npm pack --silent)
+openclaw plugins install "./$TARBALL"
+openclaw betterclaw setup
+openclaw gateway restart
+```
+
 Non-interactive setup scripts should pass an explicit profile choice:
 
 ```bash
@@ -112,7 +128,7 @@ Add to your `openclaw.json`:
       "betterclaw": {
         "enabled": true,
         "config": {
-          "triageModel": "openai/gpt-4o-mini",
+          "triageModel": "primary",
           "pushBudgetPerDay": 10,
           "patternWindowDays": 14,
           "analysisHour": 5,
@@ -130,14 +146,38 @@ All config keys are optional — defaults are shown above.
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `triageModel` | `openai/gpt-4o-mini` | Model for per-event triage and engagement classification |
-| `triageApiBase` | -- | Optional base URL for OpenAI-compatible endpoint (e.g., Ollama) |
+| `triageModel` | `primary` | Model for per-event triage and engagement classification. `primary`/`default` uses OpenClaw's default session model without requesting a plugin model override. Concrete model refs request a subagent model override. |
+| `triageApiBase` | -- | Optional base URL for an OpenAI-compatible endpoint. When set, triage uses direct HTTP instead of OpenClaw's subagent runtime. |
 | `pushBudgetPerDay` | `10` | Max events forwarded to the agent per day |
 | `patternWindowDays` | `14` | Days of event history used for pattern computation |
 | `analysisHour` | `5` | Hour (0-23, system timezone) for daily pattern + learner analysis |
 | `calibrationDays` | `3` | Days of rules-only triage before learner profile kicks in |
 
 > **Migration from v2:** `llmModel` still works as a deprecated alias for `triageModel`. `proactiveEnabled` is ignored (proactive triggers removed in v3).
+
+To force triage onto a specific model through OpenClaw's subagent runtime, the
+gateway must explicitly allow BetterClaw to request model overrides:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "betterclaw": {
+        "subagent": {
+          "allowModelOverride": true,
+          "allowedModels": ["anthropic/claude-sonnet-4-5"]
+        },
+        "config": {
+          "triageModel": "anthropic/claude-sonnet-4-5"
+        }
+      }
+    }
+  }
+}
+```
+
+If `triageApiBase` is set, `triageModel` is sent to that OpenAI-compatible HTTP
+endpoint instead of OpenClaw's subagent runtime.
 
 ## How It Works
 

--- a/docs/diagrams/architecture.d2
+++ b/docs/diagrams/architecture.d2
@@ -1,0 +1,30 @@
+direction: down
+
+title: "BetterClaw Plugin Architecture"
+
+ios: "BetterClaw iOS" {
+  sensors: "Battery | Location | Health | Geofences"
+}
+
+plugin: "Plugin (on gateway)" {
+  tier_gate: "Tier Gate"
+  context: "Context Store"
+  rules: "Rules Engine"
+  triage: "LLM Triage"
+  learner: "Daily Learner"
+  scanner: "Reaction Scanner"
+  patterns: "Pattern Engine"
+}
+
+agent: "AI Agent" {
+  check_tier: "check_tier"
+  get_context: "get_context"
+  node_cmds: "Node Commands\n(location.get, health.*, ...)"
+}
+
+ios -> plugin: "events + snapshots"
+plugin -> agent: "filtered push events"
+
+agent.check_tier -> plugin: "tier + routing"
+agent.get_context -> plugin: "patterns + cached state"
+agent.node_cmds -> ios: "fresh device data (premium)"

--- a/docs/diagrams/pipeline.d2
+++ b/docs/diagrams/pipeline.d2
@@ -1,0 +1,67 @@
+direction: down
+
+title: "Event Pipeline"
+
+event: "Event arrives" {
+  shape: oval
+}
+
+context_update: "Update context store"
+
+tier_check: "Tier?" {
+  shape: diamond
+}
+
+free_stored: "free_stored" {
+  shape: oval
+}
+
+jwt: "JWT check"
+
+smart_check: "Smart Mode?" {
+  shape: diamond
+}
+
+stored: "stored" {
+  shape: oval
+}
+
+rules: "Rules Engine"
+
+rules_result: "Result?" {
+  shape: diamond
+}
+
+triage: "LLM Triage\n(budget-aware, fail-closed)"
+
+push: "Push to agent" {
+  shape: oval
+}
+
+drop: "Drop" {
+  shape: oval
+}
+
+record: "Record reaction\n(pending, for scanner)"
+
+event -> context_update
+context_update -> tier_check
+
+tier_check -> free_stored: "free"
+tier_check -> jwt: "premium"
+
+jwt -> smart_check
+
+smart_check -> stored: "OFF"
+smart_check -> rules: "ON"
+
+rules -> rules_result
+
+rules_result -> push: "push"
+rules_result -> drop: "drop"
+rules_result -> triage: "ambiguous"
+
+triage -> push: "push"
+triage -> drop: "drop"
+
+push -> record

--- a/docs/logging-schema.md
+++ b/docs/logging-schema.md
@@ -142,6 +142,7 @@
 | `triage.called` | `info` | `subscriptionId`, `model` |
 | `triage.fallback` | `error` | `subscriptionId`, `fallbackAction` |
 | `triage.http.error` | `warning` | `status` |
+| `triage.model.override.rejected` | `warning` | `model` |
 | `triage.result` | `info` | `subscriptionId`, `decision` |
 
 ## Export categories

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "betterclaw",
   "name": "BetterClaw",
   "description": "Intelligent device context, event filtering, and proactive insights for BetterClaw iOS",
-  "version": "3.6.0",
+  "version": "3.6.1-dev.0",
   "main": "dist/index.js",
   "skills": ["./skills/betterclaw"],
   "configSchema": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "betterclaw",
   "name": "BetterClaw",
   "description": "Intelligent device context, event filtering, and proactive insights for BetterClaw iOS",
-  "version": "3.6.1-dev.0",
+  "version": "3.6.1",
   "main": "dist/index.js",
   "skills": ["./skills/betterclaw"],
   "configSchema": {
@@ -10,8 +10,8 @@
     "properties": {
       "triageModel": {
         "type": "string",
-        "default": "openai/gpt-4o-mini",
-        "description": "Model for per-event triage (accepts llmModel as deprecated alias)"
+        "default": "primary",
+        "description": "Model for per-event triage. Defaults to primary/default, which uses the OpenClaw session's default agent model without requesting a plugin model override. Concrete model refs require plugins.entries.betterclaw.subagent.allowModelOverride=true unless triageApiBase is set."
       },
       "llmModel": {
         "type": "string",
@@ -19,7 +19,7 @@
       },
       "triageApiBase": {
         "type": "string",
-        "description": "Optional base URL for OpenAI-compatible triage endpoint (e.g. http://localhost:11434/v1 for Ollama)"
+        "description": "Optional base URL for OpenAI-compatible triage endpoint. When set, triage uses direct OpenAI-compatible HTTP instead of the OpenClaw subagent runtime."
       },
       "pushBudgetPerDay": {
         "type": "number",
@@ -64,7 +64,7 @@
     "additionalProperties": false
   },
   "uiHints": {
-    "triageModel": { "label": "Triage Model", "placeholder": "openai/gpt-4o-mini" },
+    "triageModel": { "label": "Triage Model", "placeholder": "primary" },
     "pushBudgetPerDay": { "label": "Push Budget / Day", "type": "number" },
     "proactiveEnabled": { "label": "Proactive Insights", "type": "boolean" },
     "analysisHour": { "label": "Analysis Hour (0-23)", "type": "number" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better_openclaw/betterclaw",
-  "version": "3.6.0",
+  "version": "3.6.1-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better_openclaw/betterclaw",
-      "version": "3.6.0",
+      "version": "3.6.1-dev.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better_openclaw/betterclaw",
-  "version": "3.6.1-dev.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better_openclaw/betterclaw",
-      "version": "3.6.1-dev.0",
+      "version": "3.6.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better_openclaw/betterclaw",
-  "version": "3.6.1-dev.0",
+  "version": "3.6.1",
   "description": "Intelligent event filtering, context tracking, and proactive triggers for BetterClaw",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better_openclaw/betterclaw",
-  "version": "3.6.0",
+  "version": "3.6.1-dev.0",
   "description": "Intelligent event filtering, context tracking, and proactive triggers for BetterClaw",
   "license": "AGPL-3.0-only",
   "repository": {
@@ -8,15 +8,29 @@
     "url": "https://github.com/BetterClaw-app/betterclaw.git"
   },
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/",
+    "skills/",
+    "openclaw.plugin.json",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "schema:gen": "tsx scripts/generate-schema-doc.ts"
   },
   "openclaw": {
     "extensions": [
-      "./src/index.ts"
-    ]
+      "./dist/index.js"
+    ],
+    "install": {
+      "minHostVersion": ">=2026.4.14"
+    }
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const DEFAULT_COOLDOWNS: Record<string, number> = {
 };
 
 const AGENT_PROFILE_SYNC_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
-const PLUGIN_VERSION = "3.6.0-dev.0";
+const PLUGIN_VERSION = "3.6.1-dev.0";
 
 const BETTERCLAW_CLI_OPTIONS = {
   commands: ["betterclaw"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,8 @@ const DEFAULT_COOLDOWNS: Record<string, number> = {
 };
 
 const AGENT_PROFILE_SYNC_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
-const PLUGIN_VERSION = "3.6.1-dev.0";
+const PLUGIN_VERSION = "3.6.1";
+const FALLBACK_TRIAGE_MODEL = "openai/gpt-5.4";
 
 const BETTERCLAW_CLI_OPTIONS = {
   commands: ["betterclaw"],
@@ -50,7 +51,8 @@ const BETTERCLAW_CLI_OPTIONS = {
 };
 
 const DEFAULT_CONFIG: PluginConfig = {
-  triageModel: "openai/gpt-4o-mini",
+  triageModel: FALLBACK_TRIAGE_MODEL,
+  triageModelUsesOpenClawDefault: true,
   triageApiBase: undefined,
   pushBudgetPerDay: 10,
   patternWindowDays: 14,
@@ -60,10 +62,79 @@ const DEFAULT_CONFIG: PluginConfig = {
   defaultCooldown: 1800,
 };
 
-export function resolveConfig(raw: Record<string, unknown> | undefined): PluginConfig {
+function normalizeModelSelection(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (value && typeof value === "object") {
+    const primary = (value as { primary?: unknown }).primary;
+    if (typeof primary === "string") {
+      const trimmed = primary.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    }
+  }
+  return undefined;
+}
+
+function normalizeConfiguredTriageModel(value: unknown): string | undefined {
+  const model = normalizeModelSelection(value);
+  if (!model) return undefined;
+  const normalized = model.toLowerCase();
+  if (normalized === "primary" || normalized === "default") return undefined;
+  return model;
+}
+
+function resolveRuntimeDefaultModel(api: OpenClawPluginApi): string {
+  const defaults = (api.runtime.agent as { defaults?: { provider?: string; model?: string } }).defaults;
+  const provider = defaults?.provider;
+  const model = defaults?.model;
+  if (!model) return FALLBACK_TRIAGE_MODEL;
+  if (model.includes("/")) return model;
+  return provider ? `${provider}/${model}` : model;
+}
+
+export function resolveOpenClawPrimaryModel(runtimeConfig: Record<string, unknown> | undefined, fallback = FALLBACK_TRIAGE_MODEL): string {
+  const agents = runtimeConfig?.agents && typeof runtimeConfig.agents === "object"
+    ? runtimeConfig.agents as { defaults?: { model?: unknown }; list?: Array<{ id?: unknown; default?: unknown; model?: unknown }> }
+    : undefined;
+
+  if (agents) {
+    let defaultAgentId: string | undefined;
+    try {
+      defaultAgentId = resolveDefaultAgentId(runtimeConfig as any);
+    } catch {
+      defaultAgentId = undefined;
+    }
+
+    const defaultAgent = defaultAgentId
+      ? agents.list?.find((agent) => agent.id === defaultAgentId)
+      : agents.list?.find((agent) => agent.default === true) ?? agents.list?.[0];
+    const agentModel = normalizeModelSelection(defaultAgent?.model);
+    if (agentModel) return agentModel;
+
+    const defaultModel = normalizeModelSelection(agents.defaults?.model);
+    if (defaultModel) return defaultModel;
+  }
+
+  return fallback;
+}
+
+function resolveRuntimeConfigForDefaults(api: OpenClawPluginApi): Record<string, unknown> | undefined {
+  try {
+    return (api.config ?? api.runtime.config.loadConfig()) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveConfig(raw: Record<string, unknown> | undefined, defaultTriageModel = FALLBACK_TRIAGE_MODEL): PluginConfig {
   const cfg = raw ?? {};
+  const configuredTriageModel = normalizeConfiguredTriageModel(cfg.triageModel)
+    ?? normalizeConfiguredTriageModel(cfg.llmModel);
   return {
-    triageModel: (cfg.triageModel as string) ?? (cfg.llmModel as string) ?? "openai/gpt-4o-mini",
+    triageModel: configuredTriageModel ?? defaultTriageModel,
+    triageModelUsesOpenClawDefault: configuredTriageModel == null,
     triageApiBase: (cfg.triageApiBase as string) ?? undefined,
     pushBudgetPerDay: typeof cfg.pushBudgetPerDay === "number" && cfg.pushBudgetPerDay > 0 ? cfg.pushBudgetPerDay : 10,
     patternWindowDays: typeof cfg.patternWindowDays === "number" && cfg.patternWindowDays > 0 ? cfg.patternWindowDays : 14,
@@ -102,7 +173,9 @@ export default {
       return;
     }
 
-    const config = resolveConfig(api.pluginConfig as Record<string, unknown> | undefined);
+    const runtimeConfigForDefaults = resolveRuntimeConfigForDefaults(api);
+    const defaultTriageModel = resolveOpenClawPrimaryModel(runtimeConfigForDefaults, resolveRuntimeDefaultModel(api));
+    const config = resolveConfig(api.pluginConfig as Record<string, unknown> | undefined, defaultTriageModel);
     const stateDir = api.runtime.state.resolveStateDir();
     const diagnosticLogger = initDiagnosticLogger(path.join(stateDir, "logs"), api.logger);
     const redactionKey = randomBytes(32);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -5,6 +5,7 @@ import type { RulesEngine } from "./filter.js";
 import type { ReactionTracker } from "./reactions.js";
 import type { DeviceEvent, DeviceContext, PluginConfig } from "./types.js";
 import { triageEvent } from "./triage.js";
+import type { TriageModelRunner } from "./triage.js";
 import { requireEntitlement } from "./jwt.js";
 import { errorFields } from "./errors.js";
 import { dlog } from "./diagnostic-logger.js";
@@ -24,6 +25,92 @@ export interface PipelineDeps {
   stateDir: string;
   routing: RoutingConfigStore;
   audit: AuditLog;
+}
+
+function splitModelRef(ref: string): { provider?: string; model: string } {
+  const parts = ref.split("/");
+  if (parts.length <= 1) return { model: ref };
+  return { provider: parts[0], model: parts.slice(1).join("/") };
+}
+
+function assistantContent(messages: unknown[]): string | null {
+  const lastAssistant = (messages as any[]).filter((message) => message?.role === "assistant").pop();
+  if (!lastAssistant) return null;
+  if (typeof lastAssistant.content === "string") return lastAssistant.content;
+  if (Array.isArray(lastAssistant.content)) {
+    return lastAssistant.content
+      .filter((block: any) => block?.type === "text" && typeof block.text === "string")
+      .map((block: any) => block.text)
+      .join("");
+  }
+  return null;
+}
+
+function buildTriageRunArgs(input: {
+  sessionKey: string;
+  message: string;
+  event: DeviceEvent;
+  model: string;
+  useModelOverride: boolean;
+}): Record<string, unknown> {
+  const args: Record<string, unknown> = {
+    sessionKey: input.sessionKey,
+    message: input.message,
+    deliver: false,
+    idempotencyKey: `betterclaw-triage-${input.event.subscriptionId}-${Math.floor(input.event.firedAt)}`,
+  };
+
+  if (input.useModelOverride) {
+    const modelRef = splitModelRef(input.model);
+    args.model = modelRef.model;
+    if (modelRef.provider) args.provider = modelRef.provider;
+  }
+
+  return args;
+}
+
+function isModelOverrideRejection(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+  return lower.includes("allowmodeloverride")
+    || lower.includes("model override")
+    || lower.includes("override requests are rejected");
+}
+
+export function createTriageModelRunner(deps: PipelineDeps): TriageModelRunner {
+  return async ({ prompt, model, useModelOverride, event }) => {
+    const sessionKey = "betterclaw-triage";
+    const message = `${prompt}\n\nIMPORTANT: Respond with ONLY a JSON object {"action","reason","priority"}. Do NOT call any tools.`;
+    const runArgs = buildTriageRunArgs({ sessionKey, message, event, model, useModelOverride });
+
+    try { await deps.api.runtime.subagent.deleteSession({ sessionKey }); } catch { /* ignore */ }
+    try {
+      let runId: string;
+      try {
+        ({ runId } = await deps.api.runtime.subagent.run(runArgs as any));
+      } catch (err) {
+        if (!useModelOverride || !isModelOverrideRejection(err)) throw err;
+        dlog.warning("plugin.triage", "triage.model.override.rejected",
+          "triage model override rejected by OpenClaw; retrying with default session model",
+          { model, ...errorFields(err) });
+        ({ runId } = await deps.api.runtime.subagent.run({
+          sessionKey,
+          message,
+          deliver: false,
+          idempotencyKey: `betterclaw-triage-${event.subscriptionId}-${Math.floor(event.firedAt)}`,
+        }));
+      }
+      const wait = await deps.api.runtime.subagent.waitForRun({ runId, timeoutMs: 30000 });
+      const status = wait.status as string;
+      if (status !== "ok" && status !== "completed") {
+        throw new Error(wait.error ?? `triage model run ${wait.status}`);
+      }
+      const { messages } = await deps.api.runtime.subagent.getSessionMessages({ sessionKey, limit: 5 });
+      return assistantContent(messages);
+    } finally {
+      try { await deps.api.runtime.subagent.deleteSession({ sessionKey }); } catch { /* ignore */ }
+    }
+  };
 }
 
 export async function processEvent(deps: PipelineDeps, event: DeviceEvent): Promise<void> {
@@ -156,11 +243,13 @@ export async function processEvent(deps: PipelineDeps, event: DeviceEvent): Prom
         routing.quietHours, currentLocalTime,
         {
           triageModel: config.triageModel,
+          triageModelUsesOpenClawDefault: config.triageModelUsesOpenClawDefault,
           triageApiBase: config.triageApiBase,
           budgetUsed: context.get().meta.pushesToday,
           budgetTotal: effectiveBudget,
         },
         resolveApiKey,
+        createTriageModelRunner(deps),
       );
     } catch (err) {
       // Hard fallback: if triageEvent throws synchronously before its own try/catch,

--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -185,6 +185,7 @@ export const MANIFEST: {
         "triage.result":     { level: "info",    requiredKeys: ["subscriptionId", "decision"] },
         "triage.fallback":   { level: "error",   requiredKeys: ["subscriptionId", "fallbackAction"] },
         "triage.http.error": { level: "warning", requiredKeys: ["status"] },
+        "triage.model.override.rejected": { level: "warning", requiredKeys: ["model"] },
       },
     },
     "plugin.context": {

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -10,6 +10,13 @@ export interface TriageResult {
   priority?: "low" | "normal" | "high";
 }
 
+export type TriageModelRunner = (input: {
+  prompt: string;
+  model: string;
+  useModelOverride: boolean;
+  event: DeviceEvent;
+}) => Promise<string | null | undefined>;
+
 export function buildTriagePrompt(
   event: DeviceEvent,
   context: ContextManager,
@@ -115,8 +122,15 @@ export async function triageEvent(
   recentUserEdits: AuditEntry[],
   quietHours: { start: string; end: string; tz: string },
   currentLocalTime: string,
-  config: { triageModel: string; triageApiBase?: string; budgetUsed?: number; budgetTotal?: number },
+  config: {
+    triageModel: string;
+    triageModelUsesOpenClawDefault?: boolean;
+    triageApiBase?: string;
+    budgetUsed?: number;
+    budgetTotal?: number;
+  },
   resolveApiKey: () => Promise<string | undefined>,
+  runModel?: TriageModelRunner,
 ): Promise<TriageResult> {
   dlog.info("plugin.triage", "triage.called", "sending triage request", {
     subscriptionId: event.subscriptionId,
@@ -132,6 +146,24 @@ export async function triageEvent(
   );
 
   try {
+    if (runModel && !config.triageApiBase) {
+      const content = await runModel({
+        prompt,
+        model: config.triageModel,
+        useModelOverride: config.triageModelUsesOpenClawDefault !== true,
+        event,
+      });
+      if (!content) return { action: "drop", reason: "empty triage response — defaulting to drop" };
+
+      const result = parseTriageResponse(content);
+      dlog.info("plugin.triage", "triage.result", "triage decision", {
+        subscriptionId: event.subscriptionId,
+        decision: result.action,
+        reason: result.reason,
+      });
+      return result;
+    }
+
     const apiKey = await resolveApiKey();
     if (!apiKey) return { action: "drop", reason: "no API key for triage — defaulting to drop" };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export interface Patterns {
 
 export interface PluginConfig {
   triageModel: string;
+  triageModelUsesOpenClawDefault?: boolean;
   triageApiBase?: string;
   pushBudgetPerDay: number;
   patternWindowDays: number;

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -38,6 +38,7 @@ vi.stubGlobal("fetch", mockFetch);
 
 const baseConfig: PluginConfig = {
   triageModel: "openai/gpt-4o-mini",
+  triageApiBase: "https://api.openai.com/v1",
   pushBudgetPerDay: 3, // low for budget tests
   patternWindowDays: 7,
   proactiveEnabled: false,
@@ -160,31 +161,37 @@ afterAll(async () => {
 });
 
 describe("Scenario 1: Full event lifecycle", () => {
-  it("processes battery-low event through the full pipeline", async () => {
-    const { deps, patterns } = await makeDeps(tmpDir);
-    const event = batteryLowEvent(0.15);
+  it("processes a geofence event through the full pipeline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T14:00:00Z"));
+    try {
+      const { deps, patterns } = await makeDeps(tmpDir);
+      const event = geofenceEvent("Home", 1, Date.now() / 1000);
 
-    await processEvent(deps, event);
+      await processEvent(deps, event);
 
-    // Context updated with battery level
-    const ctx = deps.context.get();
-    expect(ctx.device.battery).not.toBeNull();
-    expect(ctx.device.battery!.level).toBe(0.15);
+      // Context updated with current zone and location label.
+      const ctx = deps.context.get();
+      expect(ctx.activity.currentZone).toBe("Home");
+      expect(ctx.device.location?.label).toBe("Home");
 
-    // Event logged with notify decision (battery-low rule is non-explicit + triage → notify)
-    const entries = await deps.events.readAll();
-    expect(entries).toHaveLength(1);
-    expect(entries[0].decision).toBe("notify");
+      // Event logged with notify decision (geofence default + triage -> notify).
+      const entries = await deps.events.readAll();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].decision).toBe("notify");
 
-    // subagent.run called with message containing marker and battery percentage
-    const runCall = (deps.api.runtime.subagent.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(runCall.message).toContain("[BetterClaw device event");
-    expect(runCall.message).toContain("15%");
+      // subagent.run called with message containing marker and geofence body.
+      const runCall = (deps.api.runtime.subagent.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(runCall.message).toContain("[BetterClaw notify");
+      expect(runCall.message).toContain("Geofence enter: Home");
 
-    // Patterns computable from the event
-    const computed = await patterns.compute();
-    expect(computed).toBeDefined();
-    expect(computed.computedAt).toBeGreaterThan(0);
+      // Patterns computable from the event.
+      const computed = await patterns.compute();
+      expect(computed).toBeDefined();
+      expect(computed.computedAt).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -352,7 +359,6 @@ describe("Scenario 4: State accumulation", () => {
 
     // Context reflects latest values
     const ctx = deps.context.get();
-    expect(ctx.device.battery!.level).toBe(0.22);
     expect(ctx.activity.currentZone).toBe("Office");
     expect(ctx.device.health!.stepsToday).toBe(8000);
 
@@ -369,30 +375,36 @@ describe("Scenario 4: State accumulation", () => {
 
 describe("Scenario 5: Cold start", () => {
   it("processes first event from fresh state with no files", async () => {
-    const freshDir = await makeTmpDir("betterclaw-e2e-cold-");
-    tmpDirs.push(freshDir);
-    const { deps, patterns } = await makeDeps(freshDir);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T14:00:00Z"));
+    try {
+      const freshDir = await makeTmpDir("betterclaw-e2e-cold-");
+      tmpDirs.push(freshDir);
+      const { deps, patterns } = await makeDeps(freshDir);
 
-    const event = batteryLowEvent(0.18);
-    await processEvent(deps, event);
+      const event = geofenceEvent("Home", 1, Date.now() / 1000);
+      await processEvent(deps, event);
 
-    // State files created
-    const eventsPath = path.join(freshDir, "events.jsonl");
-    const contextPath = path.join(freshDir, "context.json");
-    await expect(fs.access(eventsPath)).resolves.toBeUndefined();
-    await expect(fs.access(contextPath)).resolves.toBeUndefined();
+      // State files created.
+      const eventsPath = path.join(freshDir, "events.jsonl");
+      const contextPath = path.join(freshDir, "context.json");
+      await expect(fs.access(eventsPath)).resolves.toBeUndefined();
+      await expect(fs.access(contextPath)).resolves.toBeUndefined();
 
-    // Event logged (battery-low rule is non-explicit → triage → notify)
-    const entries = await deps.events.readAll();
-    expect(entries).toHaveLength(1);
-    expect(entries[0].decision).toBe("notify");
+      // Event logged (geofence rule is non-explicit -> triage -> notify).
+      const entries = await deps.events.readAll();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].decision).toBe("notify");
 
-    // Patterns computable from single event
-    const computed = await patterns.compute();
-    expect(computed).toBeDefined();
-    expect(computed.batteryPatterns.lowBatteryFrequency).not.toBeNull();
+      // Patterns computable from single event.
+      const computed = await patterns.compute();
+      expect(computed).toBeDefined();
+      expect(computed.eventStats.topSources).toContain("geofence.triggered");
 
-    // Cleanup handled by afterAll
+      // Cleanup handled by afterAll.
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -54,7 +54,7 @@ vi.mock("../src/diagnostic-logger.js", () => {
   };
 });
 
-import plugin, { resolveConfig } from "../src/index.js";
+import plugin, { resolveConfig, resolveOpenClawPrimaryModel } from "../src/index.js";
 
 // ---------------------------------------------------------------------------
 // resolveConfig
@@ -64,7 +64,8 @@ describe("resolveConfig", () => {
   it("applies all defaults when config is undefined", () => {
     const cfg = resolveConfig(undefined);
     expect(cfg).toEqual({
-      triageModel: "openai/gpt-4o-mini",
+      triageModel: "openai/gpt-5.4",
+      triageModelUsesOpenClawDefault: true,
       triageApiBase: undefined,
       pushBudgetPerDay: 10,
       patternWindowDays: 14,
@@ -83,14 +84,14 @@ describe("resolveConfig", () => {
     expect(cfg.pushBudgetPerDay).toBe(20);
     expect(cfg.proactiveEnabled).toBe(false);
     // defaults preserved
-    expect(cfg.triageModel).toBe("openai/gpt-4o-mini");
+    expect(cfg.triageModel).toBe("openai/gpt-5.4");
     expect(cfg.patternWindowDays).toBe(14);
     expect(cfg.analysisHour).toBe(5);
   });
 
   it("applies defaults for empty object", () => {
     const cfg = resolveConfig({});
-    expect(cfg.triageModel).toBe("openai/gpt-4o-mini");
+    expect(cfg.triageModel).toBe("openai/gpt-5.4");
     expect(cfg.pushBudgetPerDay).toBe(10);
   });
 
@@ -120,6 +121,41 @@ describe("resolveConfig", () => {
       llmModel: "anthropic/claude-3-haiku",
     });
     expect(cfg.triageModel).toBe("openai/gpt-4o");
+  });
+
+  it("uses the provided OpenClaw primary model as the default triage model", () => {
+    const cfg = resolveConfig(undefined, "anthropic/claude-sonnet-4-5");
+    expect(cfg.triageModel).toBe("anthropic/claude-sonnet-4-5");
+  });
+
+  it("treats primary/default triageModel values as dynamic OpenClaw primary aliases", () => {
+    expect(resolveConfig({ triageModel: "primary" }, "anthropic/claude-sonnet-4-5").triageModel)
+      .toBe("anthropic/claude-sonnet-4-5");
+    expect(resolveConfig({ llmModel: "default" }, "google/gemini-3-pro").triageModel)
+      .toBe("google/gemini-3-pro");
+  });
+
+  it("resolves OpenClaw primary model from the default agent before agent defaults", () => {
+    const model = resolveOpenClawPrimaryModel({
+      agents: {
+        defaults: { model: "openai/gpt-5.4" },
+        list: [
+          { id: "ops", model: "anthropic/claude-haiku" },
+          { id: "main", default: true, model: { primary: "google/gemini-3-pro" } },
+        ],
+      },
+    });
+    expect(model).toBe("google/gemini-3-pro");
+  });
+
+  it("resolves OpenClaw primary model from agent defaults when no default agent model is set", () => {
+    const model = resolveOpenClawPrimaryModel({
+      agents: {
+        defaults: { model: { primary: "openrouter/qwen3" } },
+        list: [{ id: "main", default: true }],
+      },
+    });
+    expect(model).toBe("openrouter/qwen3");
   });
 
   it("merges custom deduplication cooldowns with defaults", () => {

--- a/test/orchestrators/pipeline.test.ts
+++ b/test/orchestrators/pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { processEvent } from "../../src/pipeline.js";
+import { createTriageModelRunner, processEvent } from "../../src/pipeline.js";
 import { makeTmpDir } from "../helpers.js";
 import type { PipelineDeps } from "../../src/pipeline.js";
 import { ContextManager } from "../../src/context.js";
@@ -91,6 +91,7 @@ describe("pipeline integration", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     tmpDir = await makeTmpDir("betterclaw-pipeline-");
   });
 
@@ -265,5 +266,93 @@ describe("pipeline integration", () => {
     expect(entries[0].reason).toContain("smartMode off");
     expect(triageSpy).not.toHaveBeenCalled();
     expect(mockApi.runtime.subagent.run).not.toHaveBeenCalled();
+  });
+
+  it("triage runner uses the OpenClaw default session model without provider/model override", async () => {
+    const api = {
+      runtime: {
+        subagent: {
+          deleteSession: vi.fn().mockResolvedValue(undefined),
+          run: vi.fn().mockResolvedValue({ runId: "run-default" }),
+          waitForRun: vi.fn().mockResolvedValue({ status: "completed" }),
+          getSessionMessages: vi.fn().mockResolvedValue({
+            messages: [{ role: "assistant", content: '{"action":"push","reason":"ok","priority":"normal"}' }],
+          }),
+        },
+      },
+    };
+    const runner = createTriageModelRunner({ api } as unknown as PipelineDeps);
+
+    const content = await runner({
+      prompt: "decide",
+      model: "anthropic/claude-sonnet-4-5",
+      useModelOverride: false,
+      event: makeEvent(),
+    });
+
+    const args = api.runtime.subagent.run.mock.calls[0][0];
+    expect(args.provider).toBeUndefined();
+    expect(args.model).toBeUndefined();
+    expect(content).toContain('"action":"push"');
+  });
+
+  it("triage runner requests provider/model only for explicit triageModel overrides", async () => {
+    const api = {
+      runtime: {
+        subagent: {
+          deleteSession: vi.fn().mockResolvedValue(undefined),
+          run: vi.fn().mockResolvedValue({ runId: "run-override" }),
+          waitForRun: vi.fn().mockResolvedValue({ status: "completed" }),
+          getSessionMessages: vi.fn().mockResolvedValue({
+            messages: [{ role: "assistant", content: '{"action":"notify","reason":"ok","priority":"normal"}' }],
+          }),
+        },
+      },
+    };
+    const runner = createTriageModelRunner({ api } as unknown as PipelineDeps);
+
+    await runner({
+      prompt: "decide",
+      model: "anthropic/claude-sonnet-4-5",
+      useModelOverride: true,
+      event: makeEvent(),
+    });
+
+    const args = api.runtime.subagent.run.mock.calls[0][0];
+    expect(args.provider).toBe("anthropic");
+    expect(args.model).toBe("claude-sonnet-4-5");
+  });
+
+  it("triage runner retries with the default session model when OpenClaw rejects a model override", async () => {
+    const api = {
+      runtime: {
+        subagent: {
+          deleteSession: vi.fn().mockResolvedValue(undefined),
+          run: vi.fn()
+            .mockRejectedValueOnce(new Error("model override rejected; set allowModelOverride"))
+            .mockResolvedValueOnce({ runId: "run-fallback" }),
+          waitForRun: vi.fn().mockResolvedValue({ status: "completed" }),
+          getSessionMessages: vi.fn().mockResolvedValue({
+            messages: [{ role: "assistant", content: '{"action":"push","reason":"fallback","priority":"normal"}' }],
+          }),
+        },
+      },
+    };
+    const runner = createTriageModelRunner({ api } as unknown as PipelineDeps);
+
+    await runner({
+      prompt: "decide",
+      model: "anthropic/claude-sonnet-4-5",
+      useModelOverride: true,
+      event: makeEvent(),
+    });
+
+    expect(api.runtime.subagent.run).toHaveBeenCalledTimes(2);
+    expect(api.runtime.subagent.run.mock.calls[0][0]).toEqual(expect.objectContaining({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+    }));
+    expect(api.runtime.subagent.run.mock.calls[1][0].provider).toBeUndefined();
+    expect(api.runtime.subagent.run.mock.calls[1][0].model).toBeUndefined();
   });
 });

--- a/test/orchestrators/triage.test.ts
+++ b/test/orchestrators/triage.test.ts
@@ -84,6 +84,76 @@ describe("triageEvent", () => {
     expect(result.reason).toContain("no API key");
   });
 
+  it("uses OpenClaw model runner when provided and no triageApiBase override is set", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const runModel = vi.fn(async () => JSON.stringify({
+      action: "notify",
+      reason: "primary model says notify",
+      priority: "normal",
+    }));
+    const resolveApiKey = vi.fn(async () => undefined);
+
+    const result = await triageEvent(
+      makeEvent(), makeContext(), [], new Set(), [], quietHours, currentLocalTime,
+      { triageModel: "anthropic/claude-sonnet-4-5" }, resolveApiKey, runModel,
+    );
+
+    expect(result.action).toBe("notify");
+    expect(result.reason).toBe("primary model says notify");
+    expect(runModel).toHaveBeenCalledWith(expect.objectContaining({
+      model: "anthropic/claude-sonnet-4-5",
+      useModelOverride: true,
+    }));
+    expect(resolveApiKey).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not request a model override when triage uses the OpenClaw default model", async () => {
+    const runModel = vi.fn(async () => JSON.stringify({
+      action: "push",
+      reason: "default session model says push",
+      priority: "normal",
+    }));
+
+    await triageEvent(
+      makeEvent(), makeContext(), [], new Set(), [], quietHours, currentLocalTime,
+      { triageModel: "anthropic/claude-sonnet-4-5", triageModelUsesOpenClawDefault: true },
+      async () => undefined,
+      runModel,
+    );
+
+    expect(runModel).toHaveBeenCalledWith(expect.objectContaining({
+      model: "anthropic/claude-sonnet-4-5",
+      useModelOverride: false,
+    }));
+  });
+
+  it("uses direct OpenAI-compatible HTTP when triageApiBase is set even if a model runner exists", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: '{"action":"push","reason":"http override","priority":"low"}' } }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const runModel = vi.fn(async () => {
+      throw new Error("should not run");
+    });
+
+    const result = await triageEvent(
+      makeEvent(), makeContext(), [], new Set(), [], quietHours, currentLocalTime,
+      { triageModel: "openai/gpt-4o-mini", triageApiBase: "http://localhost:11434/v1" },
+      async () => "sk-test",
+      runModel,
+    );
+
+    expect(result.action).toBe("push");
+    expect(result.reason).toBe("http override");
+    expect(runModel).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
   it("returns drop on non-OK HTTP response (429)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -2,12 +2,19 @@ import * as fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 describe("package metadata", () => {
-  it("keeps the OpenClaw manifest version in sync with package.json", async () => {
+  it("keeps OpenClaw package metadata publishable", async () => {
     const [packageJson, pluginJson] = await Promise.all([
       fs.readFile("package.json", "utf8").then(JSON.parse),
       fs.readFile("openclaw.plugin.json", "utf8").then(JSON.parse),
     ]);
 
     expect(pluginJson.version).toBe(packageJson.version);
+    expect(packageJson.main).toBe("./dist/index.js");
+    expect(packageJson.types).toBe("./dist/index.d.ts");
+    expect(pluginJson.main).toBe("dist/index.js");
+    expect(packageJson.openclaw.extensions).toEqual(["./dist/index.js"]);
+    expect(packageJson.openclaw.install.minHostVersion).toBe(">=2026.4.14");
+    expect(packageJson.files).toContain("dist/");
+    expect(packageJson.scripts.prepack).toBe("npm run build");
   });
 });


### PR DESCRIPTION
## Summary
- Release BetterClaw plugin v3.6.1 as the stable compatibility/runtime patch
- Default triage to OpenClaw's primary session model instead of hard-coding OpenAI
- Add explicit model override handling with fallback when OpenClaw rejects overrides
- Document source checkout installs through npm pack and refresh lifecycle coverage
- Keep public D2 diagram sources tracked while keeping private planning/spec docs out of the repo

## Verification
- npm run build
- npm test
- npm run test:e2e -- test/e2e/lifecycle.test.ts
- npm pack --pack-destination /private/tmp/bc-plugin-pack.w8UPCP --json
- OpenClaw isolated tarball install + plugins inspect + betterclaw setup --dry-run --agent-profile no
- d2 docs/diagrams/architecture.d2 /private/tmp/betterclaw-architecture-check.svg
- d2 docs/diagrams/pipeline.d2 /private/tmp/betterclaw-pipeline-check.svg
- Fresh mirror clone: no reachable docs/plans or docs/specs paths; docs/diagrams/*.d2 and README SVGs present
- GitHub release v3.6.1 published and npm latest verified at 3.6.1